### PR TITLE
Card updates

### DIFF
--- a/guide/components.html
+++ b/guide/components.html
@@ -379,7 +379,7 @@
         <div class="row">
           <div class="col-lg-6">
             <div class="card mb-4">
-              <div class="card-body">
+              <div class="card-body text-xs-center">
                 <img class="icon" src="images/icon-visualizations.png" alt="" />
                 <h4 class="card-title mt-4">Large Card</h4>
                 <p>For certain types of information such as links to multiple apps or studies, developers may which to utilize the card approach featured throughout the intro pages.</p>

--- a/scss/_sjc-card.scss
+++ b/scss/_sjc-card.scss
@@ -1,13 +1,3 @@
-.card {
-  text-align: center;
-  box-shadow: 0 0 6px #000;
-}
-
-.card-header {
-  color: #fff;
-  background-color: $primary;
-}
-
 .card img {
   width: 100%;
   max-width: 100%;


### PR DESCRIPTION
The cards as defined were having unintended consequences on PeCan. I've done the following:

- remove the shadow, and default centering
- remove the card header's coloring.

The guide was updated to center the text as per bootstrap. The removal of shadow is subjective but it looks much better without it.