### PR TITLE
Resolve CI failures

### DIFF
--- a/.github/workflows/azure-static-web-apps-delightful-wave-007c8ea0f.yml
+++ b/.github/workflows/azure-static-web-apps-delightful-wave-007c8ea0f.yml
@@ -2,12 +2,10 @@ name: Azure Static Web Apps CI/CD
 
 on:
   push:
-    branches:
-      - master
+    branches: [ $default-branch ]
   pull_request:
     types: [opened, synchronize, reopened, closed]
-    branches:
-      - master
+    branches: [ $default-branch ]
 
 jobs:
   build_and_deploy_job:
@@ -15,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
         with:
           submodules: true
       - name: Build And Deploy

--- a/.github/workflows/azure-static-web-apps-delightful-wave-007c8ea0f.yml
+++ b/.github/workflows/azure-static-web-apps-delightful-wave-007c8ea0f.yml
@@ -2,10 +2,12 @@ name: Azure Static Web Apps CI/CD
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches:
+      - master
   pull_request:
     types: [opened, synchronize, reopened, closed]
-    branches: [ $default-branch ]
+    branches:
+      - master
 
 jobs:
   build_and_deploy_job:
@@ -13,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2
         with:
           submodules: true
       - name: Build And Deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,18 +2,17 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
+    branches: [ $default-branch ]
 
 jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.2
-      - uses: actions/setup-node@v1.4.3
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-node@v1.4.4
         with:
           node-version: 12.x
-      - uses: actions/cache@v2.1.1
+      - uses: actions/cache@v2.1.3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -21,7 +20,7 @@ jobs:
             ${{ runner.os }}-node-
       - run: npm install
       - run: npm run build
-      - uses: peaceiris/actions-gh-pages@v3.6.4
+      - uses: peaceiris/actions-gh-pages@v3.7.3
         with:
           deploy_key: ${{ secrets.DEPLOY_KEY }}
           publish_dir: fractal-build


### PR DESCRIPTION
This PR updates the workflow actions to resolve build failures due to [CVE-2020-15228](https://github.com/advisories/GHSA-mfwh-5m23-j46w).

~~Branch triggers have also been updated to use the new `$default-branch` macro and the line endings for the SWA workflow have been changed from Windows to Unix.~~