### PR TITLE
fix: hexcode for purple on colors page

### DIFF
--- a/components/colors/colors.hbs
+++ b/components/colors/colors.hbs
@@ -170,7 +170,7 @@
       <div class="card bg-purple col-4">
         <div class="card-body">
           <h4 class="card-title text-white">Nnon-Cancerous Diseases</h4>
-          <p class="card-text text-white">#AEB2B5 <small>$non-cancerous-diseases</small></p>
+          <p class="card-text text-white">#8332A7 <small>$non-cancerous-diseases</small></p>
         </div>
       </div>
     </div>
@@ -222,7 +222,7 @@
       <div class="card bg-purple col-3">
         <div class="card-body">
           <h4 class="card-title text-white">Purple</h4>
-          <p class="card-text text-white">#AEB2B5 <small>$purple / $info / $non-cancerous-diseases</small></p>
+          <p class="card-text text-white">#8332A7 <small>$purple / $info / $non-cancerous-diseases</small></p>
         </div>
       </div>
       <div class="col-3">


### PR DESCRIPTION
When I pulled this hexcode from the text on the page, I did a double-take that my program wasn't set to B&W since it was coming in gray. :) 

The color rendered properly on the colors page just didn't display the correct value on the card.