### PR TITLE
Fix logo svg styling in footer and omnibar

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ This repository provides theme guidelines and plug-n-play style components for S
 
 `npm run watch` is also provided for continuous compilation during development.
 
+### To View React Components in Storybook
+- Navigate to the React packages folder: `cd packages/stjude-cloud-theme-react`
+- Install Storybook: `npm install`
+- Start Storybook: `npm run storybook`
+
 ## Contributing
 
 **You do not need to commit changes to `dist/css/*` as part of your pull request.** This directory will be updated on release.

--- a/packages/stjude-cloud-theme-react/src/Navbar.js
+++ b/packages/stjude-cloud-theme-react/src/Navbar.js
@@ -89,7 +89,7 @@ function Navbar({ children, portalConfig, loginConfig, userDropdownConfig}) {
     <header className="sjc-omnibar">
       <BSNavbar variant="">
         <BSNavbar.Brand href="https://stjude.cloud" title="St. Jude Cloud" alt="St. Jude Cloud">
-          <span className="logo hide-text">St. Jude Cloud</span>
+          <span className="logo"></span>
         </BSNavbar.Brand>
         <a className="sjc-title" href="https://stjude.cloud" title="St. Jude Cloud">
           St. Jude Cloud

--- a/scss/_sjc-footer.scss
+++ b/scss/_sjc-footer.scss
@@ -10,9 +10,9 @@ footer {
     padding: 20px 30px;
     color: $white;
     background-image: url('#{$stjude-images-path}/stjude-logo-child.svg');
-    background-size: 55px;
     background-position: 0px 3px;
     background-repeat: no-repeat;
+    background-size: 55px;
     border-color: #99C4F4;
     border-right: 1px solid;
   }

--- a/scss/_sjc-footer.scss
+++ b/scss/_sjc-footer.scss
@@ -10,8 +10,9 @@ footer {
     padding: 20px 30px;
     color: $white;
     background-image: url('#{$stjude-images-path}/stjude-logo-child.svg');
-    background-position: 3px 6px;
-    background-size: 72px;
+    background-size: 55px;
+    background-position: 0px 3px;
+    background-repeat: no-repeat;
     border-color: #99C4F4;
     border-right: 1px solid;
   }

--- a/scss/_sjc-navbar.scss
+++ b/scss/_sjc-navbar.scss
@@ -57,8 +57,9 @@
     padding: 20px 30px;
     color: $white;
     background-image: url("#{$stjude-images-path}/stjude-logo-child.svg");
-    background-position: 3px 6px;
-    background-size: 72px;
+    background-position: 0px 3px;
+    background-size: 55px;
+    background-repeat: no-repeat;
     border-color: #99c4f4;
     border-right: 1px solid;
   }

--- a/scss/_sjc-navbar.scss
+++ b/scss/_sjc-navbar.scss
@@ -58,8 +58,8 @@
     color: $white;
     background-image: url("#{$stjude-images-path}/stjude-logo-child.svg");
     background-position: 0px 3px;
-    background-size: 55px;
     background-repeat: no-repeat;
+    background-size: 55px;
     border-color: #99c4f4;
     border-right: 1px solid;
   }


### PR DESCRIPTION
The styling around the svg logo used in the omnibar and footer busted – thanks, Drew, for the catch. I made a couple of minor css changes to fix those and added a few commands re storybook to the readme. 