### PR TITLE
refactor(copyright): makes the copyright date dynamic in the footer

### DIFF
--- a/components/footer/footer.hbs
+++ b/components/footer/footer.hbs
@@ -83,7 +83,7 @@
         </div>
         <div class="col-xl-6 col-md-12 col-8 offset-md-0 offset-2">
           <p>
-          &copy; Copyright 2020 <a href="https://www.stjude.org" title="St. Jude Children's Research Hospital" target="_blank">St. Jude Children's Research Hospital</a>, a not-for-profit, section 501(c)(3).</p>
+          &copy; Copyright <script type="text/javascript">document.write(new Date().getFullYear());</script> <a href="https://www.stjude.org" title="St. Jude Children's Research Hospital" target="_blank">St. Jude Children's Research Hospital</a>, a not-for-profit, section 501(c)(3).</p>
         </div>
       </div>
     </div>

--- a/packages/stjude-cloud-theme-react/src/Footer.js
+++ b/packages/stjude-cloud-theme-react/src/Footer.js
@@ -257,7 +257,7 @@ function Footer() {
               xl={6}
             >
               <p>
-                &copy; Copyright 2020 St. Jude Children's Research Hospital, a
+                &copy; Copyright {new Date().getFullYear()} St. Jude Children's Research Hospital, a
                 not-for-profit, section 501(c)(3).
               </p>
             </Col>


### PR DESCRIPTION
The footer was sitting at 2020 copyright, I've just changed this to make it dynamic based on the current calculated year.