### PR TITLE
docs: update readme to expound on package interdependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,26 @@ This repository provides assets, styling libraries, and component libraries as p
 |              Package               |                  Folder                  | Published to NPM | Description                                                                                                                                                                      |
 | :--------------------------------: | :--------------------------------------: | :--------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 |       `@stjudecloud/assets`        |          [`assets/`](https://github.com/stjudecloud/theme/tree/main/assets)           |       YES        | Contains all, non-minified assets used on the St. Jude Cloud project.                                                                                                            |
-|   `@stjudecloud/theme-bootstrap`   | [`themes/bootstrap`](https://github.com/stjudecloud/theme/tree/main/themes/bootstrap) |       YES        | Both production-ready and development files for the Bootstrap St. Jude Cloud theme                                                                                               |
-|      `@stjudecloud/ui-react`       |   [`packages/react`](https://github.com/stjudecloud/theme/tree/main/packages/react)   |       YES        | Production-ready React component library for the St. Jude Cloud design system. Note that CSS from `@stjudecloud/theme-bootstrap` must be loaded for elements to render properly. |
-| `@stjudecloud/design.stjude.cloud` |         [`fractal/`](https://github.com/stjudecloud/theme/tree/main/fractal)          |        NO        | Fractal source code for rendering [https://design.stjude.cloud](https://design.stjude.cloud)                                                                                     |
+|   `@stjudecloud/theme-bootstrap`   | [`themes/bootstrap`](https://github.com/stjudecloud/theme/tree/main/themes/bootstrap) |       YES        | Both production-ready and development files for the Bootstrap St. Jude Cloud theme.                                                                                               |
+|      `@stjudecloud/ui-react`       |   [`packages/react`](https://github.com/stjudecloud/theme/tree/main/packages/react)   |       YES        | Production-ready React component library for the St. Jude Cloud design system.  |
+| `@stjudecloud/design.stjude.cloud` |         [`fractal/`](https://github.com/stjudecloud/theme/tree/main/fractal)          |        NO        | Fractal source code for rendering [https://design.stjude.cloud](https://design.stjude.cloud).                                                                                     |
+
+## Publish Features Across Packages
+
+While this repo features several packages that you can pull into a project
+independently, it should be noted that there are some interdependencies between
+the repo&#39;s packages which could affect the order in which you make your changes. 
+
+For example, if you want to add an app to the omnibar, you should
+make changes and publish the image to the assets package to then use it in
+rendering the DSM or creating a component. The same idea applies if you
+need to make styling changes in the Bootstrap package that you would then use in
+a framework component. Refer to the table below for
+guidance on how these packages affect one another. 
+
+|            Package                   |               St. Jude Cloud Dependencies| 
+|  :-------------------------------:   | :------------------------------------------------------: | 
+|        `@stjudecloud/assets`         |                        None                              |
+|    `@stjudecloud/theme-bootstrap`    |                        None                              |        
+|       `@stjudecloud/ui-react`        |  `@stjudecloud/assets` & `@stjudecloud/theme-bootstrap`  |       
+|  `@stjudecloud/design.stjude.cloud`  |  `@stjudecloud/assets` & `@stjudecloud/theme-bootstrap`  |


### PR DESCRIPTION
Given the multiple PRs and branches, I wanted to further document the dependencies between packages in this repo. I culled out a phrase from the original packages table in the top-level readme in order to expand on the idea in another section. 