### PR TITLE
chore: update to latest node and ubuntu in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 18.x
       - uses: actions/cache@v2
         with:
           path: ~/.npm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,19 +4,19 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 18.x
       - run: npm run lint
   build-bootstrap:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 18.x
       - run: npm i && npm run build
         working-directory: themes/bootstrap


### PR DESCRIPTION
This PR updates the workflow files' `node` version to `18.x.x` and uses `ubuntu-latest`