### PR TITLE
Chore/add nav links config

### DIFF
--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stjudecloud/ui-react",
-  "version": "5.1.12",
+  "version": "5.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stjudecloud/ui-react",
-      "version": "5.1.12",
+      "version": "5.1.13",
       "license": "UNLICENSED",
       "dependencies": {
         "@babel/runtime": "^7.14.8",

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stjudecloud/ui-react",
-  "version": "5.1.11",
+  "version": "5.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stjudecloud/ui-react",
-      "version": "5.1.11",
+      "version": "5.1.12",
       "license": "UNLICENSED",
       "dependencies": {
         "@babel/runtime": "^7.14.8",

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/runtime": "^7.14.8",
         "@stjudecloud/assets": "^1.0.0",
-        "@stjudecloud/theme-bootstrap": "^5.1.10",
+        "@stjudecloud/theme-bootstrap": "^5.1.12",
         "cherry-pick": "^0.5.0",
         "prop-types": "^15.7.2"
       },
@@ -2983,9 +2983,9 @@
       "integrity": "sha512-Tmk/eJCha0+RPxCLoM0Fb1+pgs8xDISY/LIT2VlU3sisslqonzmAAUVIdGLYQZtcvhHckurW0mA29STqOMxYRg=="
     },
     "node_modules/@stjudecloud/theme-bootstrap": {
-      "version": "5.1.10",
-      "resolved": "https://registry.npmjs.org/@stjudecloud/theme-bootstrap/-/theme-bootstrap-5.1.10.tgz",
-      "integrity": "sha512-VXZwYd69z8ClkdVnzeA64d9ZxNriLLJh/rORSnzNpo+/lq6c/Bxv3M9T90cU625rkVbzf1KZZj6eK7shmI+LZg==",
+      "version": "5.1.12",
+      "resolved": "https://registry.npmjs.org/@stjudecloud/theme-bootstrap/-/theme-bootstrap-5.1.12.tgz",
+      "integrity": "sha512-seR4LkBvYkR6beXLfXuvkqGr67BkP8Vtbxojo7eZjyqd3zfRv1DBNRT/HrP1MiMob0FRda3740fJjBUawTMstw==",
       "dependencies": {
         "@stjudecloud/assets": "^1.0.0-rc.3",
         "bootstrap": "^5.1.1"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stjudecloud/ui-react",
-  "version": "5.1.11",
+  "version": "5.1.12",
   "description": "React implementation for St. Jude Cloud Theme components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@babel/runtime": "^7.14.8",
     "@stjudecloud/assets": "^1.0.0",
-    "@stjudecloud/theme-bootstrap": "^5.1.10",
+    "@stjudecloud/theme-bootstrap": "^5.1.12",
     "cherry-pick": "^0.5.0",
     "prop-types": "^15.7.2"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stjudecloud/ui-react",
-  "version": "5.1.12",
+  "version": "5.1.13",
   "description": "React implementation for St. Jude Cloud Theme components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/react/src/Navbar.js
+++ b/packages/react/src/Navbar.js
@@ -31,8 +31,27 @@ const propTypes = {
   }),
   navLinksConfig: PropTypes.shape({
     show: PropTypes.bool,
-    navLinks: PropTypes.node,
+    navLinks: PropTypes.arrayOf(
+      PropTypes.shape({
+        link: PropTypes.string,
+        content: PropTypes.oneOf([PropTypes.node, PropTypes.string]),
+        externalRoute: PropTypes.bool,
+        newTab: PropTypes.bool,
+      })
+    ),
   }),
+};
+
+const getNavLinkProps = ({ externalRoute, link, newTab, children }) => {
+  if (!externalRoute) return { as: Link, to: link };
+
+  let props = {
+    as: "a",
+    href: link,
+  };
+
+  if (newTab) return { ...props, target: "_blank", rel: "noopener noreferrer" };
+  return props;
 };
 
 function Navbar({
@@ -109,7 +128,11 @@ function Navbar({
   if (navLinksConfig && navLinksConfig.show) {
     navbarLinks = (
       <Nav className="nav-links" as="ul">
-        {navLinksConfig.navLinks}
+        {navLinksConfig.navLinks.map((navLink) => (
+          <Nav.Link key={navLink.link} {...getNavLinkProps(navLink)}>
+            {navLink.content}
+          </Nav.Link>
+        ))}
       </Nav>
     );
   }

--- a/packages/react/src/Navbar.js
+++ b/packages/react/src/Navbar.js
@@ -29,7 +29,10 @@ const propTypes = {
     additionalItems: PropTypes.node,
     initials: PropTypes.string,
   }),
-  navLinks: PropTypes.node,
+  navLinksConfig: PropTypes.shape({
+    show: PropTypes.bool,
+    navLinks: PropTypes.node,
+  }),
 };
 
 function Navbar({
@@ -37,7 +40,7 @@ function Navbar({
   portalConfig,
   loginConfig,
   userDropdownConfig,
-  navLinks,
+  navLinksConfig,
 }) {
   // Force react-bootstrap to render the dropdown markdown so CSS can animate
   // the slide on toggle. After setting `show`, immediately unset to allow
@@ -103,10 +106,10 @@ function Navbar({
   }
 
   let navbarLinks;
-  if (navLinks) {
+  if (navLinksConfig && navLinksConfig.show) {
     navbarLinks = (
       <Nav className="nav-links" as="ul">
-        {navLinks}
+        {navLinksConfig.navLinks}
       </Nav>
     );
   }
@@ -130,8 +133,8 @@ function Navbar({
             St. Jude Cloud
           </a>
           {portalElement}
-
           {navbarLinks}
+
           <Nav className="global-icons" as="ul">
             {children}
             {loginButton}

--- a/packages/react/src/Navbar.js
+++ b/packages/react/src/Navbar.js
@@ -111,6 +111,15 @@ function Navbar({
         <Dropdown.Menu className="profile-dropdown-menu" show={show}>
           <ul className="list-unstyled">
             {userDropdownConfig.additionalItems}
+            {navLinksConfig &&
+              navLinksConfig.show &&
+              navLinksConfig.navLinks.map((navLink) => (
+                <li className="collapsed-nav-link">
+                  <Dropdown.Item {...getNavLinkProps(navLink)}>
+                    {navLink.content}
+                  </Dropdown.Item>
+                </li>
+              ))}
             {userDropdownConfig.logoutLink && (
               <li>
                 <Dropdown.Item as="a" href={userDropdownConfig.logoutLink}>

--- a/packages/react/src/Navbar.js
+++ b/packages/react/src/Navbar.js
@@ -33,25 +33,17 @@ const propTypes = {
     show: PropTypes.bool,
     navLinks: PropTypes.arrayOf(
       PropTypes.shape({
-        link: PropTypes.string,
         content: PropTypes.oneOf([PropTypes.node, PropTypes.string]),
-        externalRoute: PropTypes.bool,
-        newTab: PropTypes.bool,
+        props: PropTypes.shape({
+          to: PropTypes.string,
+          href: PropTypes.string,
+          target: PropTypes.string,
+          ref: PropTypes.string,
+          onClick: PropTypes.func,
+        }),
       })
     ),
   }),
-};
-
-const getNavLinkProps = ({ externalRoute, link, newTab, children }) => {
-  if (!externalRoute) return { as: Link, to: link };
-
-  let props = {
-    as: "a",
-    href: link,
-  };
-
-  if (newTab) return { ...props, target: "_blank", rel: "noopener noreferrer" };
-  return props;
 };
 
 function Navbar({
@@ -115,9 +107,7 @@ function Navbar({
               navLinksConfig.show &&
               navLinksConfig.navLinks.map((navLink) => (
                 <li className="collapsed-nav-link">
-                  <Dropdown.Item {...getNavLinkProps(navLink)}>
-                    {navLink.content}
-                  </Dropdown.Item>
+                  <Dropdown.Item {...navLink.props} />
                 </li>
               ))}
             {userDropdownConfig.logoutLink && (
@@ -138,9 +128,7 @@ function Navbar({
     navbarLinks = (
       <Nav className="nav-links" as="ul">
         {navLinksConfig.navLinks.map((navLink) => (
-          <Nav.Link key={navLink.link} {...getNavLinkProps(navLink)}>
-            {navLink.content}
-          </Nav.Link>
+          <Nav.Link key={navLink.link} {...navLink.props} />
         ))}
       </Nav>
     );

--- a/packages/react/src/Navbar.js
+++ b/packages/react/src/Navbar.js
@@ -33,17 +33,25 @@ const propTypes = {
     show: PropTypes.bool,
     navLinks: PropTypes.arrayOf(
       PropTypes.shape({
+        link: PropTypes.string,
         content: PropTypes.oneOf([PropTypes.node, PropTypes.string]),
-        props: PropTypes.shape({
-          to: PropTypes.string,
-          href: PropTypes.string,
-          target: PropTypes.string,
-          ref: PropTypes.string,
-          onClick: PropTypes.func,
-        }),
+        externalLink: PropTypes.bool,
+        newTab: PropTypes.bool,
       })
     ),
   }),
+};
+
+const getNavLinkProps = ({ externalLink, link, newTab }) => {
+  if (!externalLink) return { as: Link, to: link };
+
+  let props = {
+    as: "a",
+    href: link,
+  };
+
+  if (newTab) return { ...props, target: "_blank", rel: "noopener noreferrer" };
+  return props;
 };
 
 function Navbar({
@@ -107,7 +115,7 @@ function Navbar({
               navLinksConfig.show &&
               navLinksConfig.navLinks.map((navLink) => (
                 <li className="collapsed-nav-link">
-                  <Dropdown.Item {...navLink.props} />
+                  <Dropdown.Item {...getNavLinkProps(navLink)}>{navLink.content}</Dropdown.Item>
                 </li>
               ))}
             {userDropdownConfig.logoutLink && (
@@ -128,7 +136,9 @@ function Navbar({
     navbarLinks = (
       <Nav className="nav-links" as="ul">
         {navLinksConfig.navLinks.map((navLink) => (
-          <Nav.Link key={navLink.link} {...navLink.props} />
+          <Nav.Link key={navLink.link} {...getNavLinkProps(navLink)}>
+            {navLink.content}
+          </Nav.Link>
         ))}
       </Nav>
     );

--- a/packages/react/stories/Navbar.stories.js
+++ b/packages/react/stories/Navbar.stories.js
@@ -89,37 +89,26 @@ NavLinks.args = {
     show: true,
     navLinks: [
       {
-        props: {
-          to: "/data",
-          as: Link,
-          children: "Data Browser",
-        },
+        link: "/data",
+        content: "Data Browser",
       },
       {
-        props: {
-          to: "/workflows",
-          as: Link,
-          children: "Workflows",
-        },
+        link: "/workflows",
+        content: "Workflows",
       },
       {
-        props: {
-          to: "/dashboard",
-          as: Link,
-          children: "My Dashboard",
-        },
+        link: "/dashboard",
+        content: "My Dashboard",
       },
       {
-        props: {
-          href: "/dnanexus",
-          target: "_blank",
-          rel: "noopener noreferrer",
-          children: (
-            <>
-              <i className="fa fa-dna" /> DNAnexus
-            </>
-          ),
-        },
+        link: "/dnanexus",
+        content: (
+          <>
+            <i className="fa fa-dna" /> DNAnexus
+          </>
+        ),
+        externalLink: true,
+        newTab: true,
       },
     ],
   },

--- a/packages/react/stories/Navbar.stories.js
+++ b/packages/react/stories/Navbar.stories.js
@@ -74,7 +74,17 @@ UserLoggedInWithInitials.args = {
 export const NavLinks = NavbarTemplate.bind({});
 NavLinks.args = {
   portalConfig: props.portalConfig,
-  userDropdownConfig: props.userDropdownConfigWithInitials,
+  userDropdownConfig: {
+    ...props.userDropdownConfigWithInitials,
+    additionalItems: (
+      <>
+        <li>
+          <Dropdown.Item disabled>Jane Doe</Dropdown.Item>
+        </li>
+        <Dropdown.Divider />
+      </>
+    ),
+  },
   navLinksConfig: {
     show: true,
     navLinks: [

--- a/packages/react/stories/Navbar.stories.js
+++ b/packages/react/stories/Navbar.stories.js
@@ -44,6 +44,9 @@ const props = {
     show: true,
     initials: "JD",
   },
+  navLinksConfig: {
+    show: true,
+  },
 };
 
 const NavbarTemplate = (props) => <Navbar {...props} />;
@@ -75,25 +78,28 @@ export const NavLinks = NavbarTemplate.bind({});
 NavLinks.args = {
   portalConfig: props.portalConfig,
   userDropdownConfig: props.userDropdownConfigWithInitials,
-  navLinks: (
-    <>
-      <Nav.Link as={Link} to="/">
-        Data Browser
-      </Nav.Link>
+  navLinksConfig: {
+    ...props.navLinksConfig,
+    navLinks: (
+      <>
+        <Nav.Link as={Link} to="/">
+          Data Browser
+        </Nav.Link>
 
-      <Nav.Link as={Link} to="/">
-        Workflows
-      </Nav.Link>
+        <Nav.Link as={Link} to="/">
+          Workflows
+        </Nav.Link>
 
-      <Nav.Link as={Link} to="/">
-        My Dashboard
-      </Nav.Link>
+        <Nav.Link as={Link} to="/">
+          My Dashboard
+        </Nav.Link>
 
-      <Nav.Link as="a" href="/" target="_blank">
-        <i className="fa fa-dna" /> DNAnexus
-      </Nav.Link>
-    </>
-  ),
+        <Nav.Link as="a" href="/" target="_blank">
+          <i className="fa fa-dna" /> DNAnexus
+        </Nav.Link>
+      </>
+    ),
+  },
 };
 
 export const UserLoggedInDropdownWithAdditionalItems = NavbarTemplate.bind({});

--- a/packages/react/stories/Navbar.stories.js
+++ b/packages/react/stories/Navbar.stories.js
@@ -44,9 +44,6 @@ const props = {
     show: true,
     initials: "JD",
   },
-  navLinksConfig: {
-    show: true,
-  },
 };
 
 const NavbarTemplate = (props) => <Navbar {...props} />;
@@ -79,26 +76,31 @@ NavLinks.args = {
   portalConfig: props.portalConfig,
   userDropdownConfig: props.userDropdownConfigWithInitials,
   navLinksConfig: {
-    ...props.navLinksConfig,
-    navLinks: (
-      <>
-        <Nav.Link as={Link} to="/">
-          Data Browser
-        </Nav.Link>
-
-        <Nav.Link as={Link} to="/">
-          Workflows
-        </Nav.Link>
-
-        <Nav.Link as={Link} to="/">
-          My Dashboard
-        </Nav.Link>
-
-        <Nav.Link as="a" href="/" target="_blank">
-          <i className="fa fa-dna" /> DNAnexus
-        </Nav.Link>
-      </>
-    ),
+    show: true,
+    navLinks: [
+      {
+        link: "/data",
+        content: "Data Browser",
+      },
+      {
+        link: "/workflows",
+        content: "Workflows",
+      },
+      {
+        link: "/dashboard",
+        content: "My Dashboard",
+      },
+      {
+        link: "/dnanexus",
+        content: (
+          <>
+            <i className="fa fa-dna" /> DNAnexus
+          </>
+        ),
+        externalRoute: true,
+        newTab: true,
+      },
+    ],
   },
 };
 

--- a/packages/react/stories/Navbar.stories.js
+++ b/packages/react/stories/Navbar.stories.js
@@ -79,26 +79,37 @@ NavLinks.args = {
     show: true,
     navLinks: [
       {
-        link: "/data",
-        content: "Data Browser",
+        props: {
+          to: "/data",
+          as: Link,
+          children: "Data Browser",
+        },
       },
       {
-        link: "/workflows",
-        content: "Workflows",
+        props: {
+          to: "/workflows",
+          as: Link,
+          children: "Workflows",
+        },
       },
       {
-        link: "/dashboard",
-        content: "My Dashboard",
+        props: {
+          to: "/dashboard",
+          as: Link,
+          children: "My Dashboard",
+        },
       },
       {
-        link: "/dnanexus",
-        content: (
-          <>
-            <i className="fa fa-dna" /> DNAnexus
-          </>
-        ),
-        externalRoute: true,
-        newTab: true,
+        props: {
+          href: "/dnanexus",
+          target: "_blank",
+          rel: "noopener noreferrer",
+          children: (
+            <>
+              <i className="fa fa-dna" /> DNAnexus
+            </>
+          ),
+        },
       },
     ],
   },


### PR DESCRIPTION
This PR goes back to making use of `navLinksConfig` to render the `navbar` links. Likewise, the `nav` links content will get collapsed into the user `dropdown` menu when the the window size if reduced to mobile view. This will make the navbar more responsive and will provide a rich user experience